### PR TITLE
Clean up docs

### DIFF
--- a/lib/circuit_breaker/memory.rb
+++ b/lib/circuit_breaker/memory.rb
@@ -1,20 +1,38 @@
 module CircuitBreaker
   class Memory
     include CircuitBreaker
-    attr_accessor :circuit, :failure_limit, :reset_timeout, :logger, :state, :failures
-    # The main class to instantiate the CircuitBraker class.
+
+    # The main runner, must respond to #call
+    # @return [Proc/Lambda] the runner
+    attr_accessor :circuit
+    # The count of failures
+    # @return [Integer] the amount of failures to permit.  Defaults to 10 seconds
+    attr_accessor :failure_limit
+    # The amount of time in seconds before a breaker should reset if currently open.  Defaults to 5
+    # @return [Integer]
+    attr_accessor :reset_timeout
+    # The current logger
+    # @return [Object] - The logger sent in at initialization.  Defaults to ruby's std Logger class
+    attr_accessor :logger
+    # The current state
+    # @return [Symbol] should always return either :open, :closed or :half-open.
+    #   Use the helper methods in lib/circuit_breaker.rb for more readable code.
+    attr_accessor :state
+    # The current failures
+    # @return [Array<CircuitBreaker::Failure>] - a list of failures serialized.
+    attr_accessor :failures
     #
     # @example create a new breaker
-    #   breaker = CircuitBreaker.new do |cb|
+    #   breaker = CircuitBreaker::Memory.new do |cb|
     #     cb.circuit = -> (arg) { my_method(arg) }
     #     cb.failure_limit = 2
     #     cb.reset_timeout = 5
     #   end
     #
-    # @yieldparam circuit [Proc/Lambda] The method you'll want to invoke within a breaker
-    # @yieldparam failure_limit [Integer] The maximum amount of failures you'll tolerate in a row before the breaker is tripped. Defaults to 5.
-    # @yieldparam reset_timeout [Integer] The amount of time before the breaker should move back to closed after the last failure.  For instance if you set this to 5, the breaker is callable again 5+ seconds after the last failure.  Defaults to 10 seconds
-    # @yieldparam logger [Logger] A logger instance of your choosing.  Defaults to ruby's std logger.
+    # @yieldparam circuit - (look to {#circuit})
+    # @yieldparam failure_limit - (look to {#failure_limit})
+    # @yieldparam reset_timeout - (look to {#reset_timeout})
+    # @yieldparam logger - (look to {#logger})
     # @return [CircuitBreaker::Memory] the object.
     def initialize(&block)
       yield self
@@ -26,6 +44,7 @@ module CircuitBreaker
       run_validations
     end
 
+    # (look to {CircuitBreaker::add_failure})
     def add_failure(failure)
       failures << failure
     end


### PR DESCRIPTION
This PR cleans up documentation to be more reusable.  I did file a bug
on yardoc https://github.com/lsegal/yard/issues/1073 due to the keyword
see not working as the docs describe.  Links will have to do for now.